### PR TITLE
Fix: shield background

### DIFF
--- a/src/components/scoreboard/graphics/suspensions/suspension-item.tsx
+++ b/src/components/scoreboard/graphics/suspensions/suspension-item.tsx
@@ -10,10 +10,11 @@ const StyledSuspensionItem = styled.li`
   border-radius: var(--suspension-border-radius, 8px);
   margin: 0;
   padding: 2px 5px;
+  font-size: var(--suspension-font-size, 18px);
 
   &[data-number]:before {
     content: attr(data-number);
-    color: var(--suspension-number-font-color, #ccc);
+    color: var(--suspension-number-font-color, #cccccc);
     border-radius: 5px;
     padding: 1px 5px;
   }

--- a/src/components/scoreboard/graphics/suspensions/suspensions.tsx
+++ b/src/components/scoreboard/graphics/suspensions/suspensions.tsx
@@ -21,7 +21,7 @@ const StyledSuspensionsList = styled.ul`
   list-style: none;
   margin: 0 5px;
   padding: 0;
-  gap: 5px;
+  gap: 2px;
 `;
 
 export declare interface SuspensionsProps {

--- a/src/graphics/live.html
+++ b/src/graphics/live.html
@@ -32,8 +32,6 @@
         --visitor-shield-background-color: white;
         --advertising-background-color: var(--vetusta-new-yellow-color);
 
-        /* Not used yet */
-
         --space-margin: 5px;
         --scoreboard-space-margin: 10px;
         --space-magin-score-left: 15px 5px 10px;
@@ -42,7 +40,7 @@
         --score-border-radius-left: 20px 0 0 20px;
         --font-size: 22px;
         --font-color: black;
-        --font-score-size: 32px;
+        --font-score-size: 28px;
         --shield-size: 35px;
         --shield-div-scale: 1.6;
         --image-scale: 1.05;
@@ -51,6 +49,7 @@
         --font-color-info: red;
         --emty-goal-size: 16px;
 
+        --scoreboard-zoom: 1.1;
         --scoreboard-font-color: black;
 
         --stopwatch-padding: 5px 5px;
@@ -73,8 +72,8 @@
 
         --banners-max-height: 120px;
 
-
-        --font-size-card: calc(10px * var(--size-scale-factor, 1));
+        --font-size-card: 10px;
+        --suspension-font-size: 18px;
       }
 
       body {
@@ -101,6 +100,7 @@
       }
 
       .scoreboard {
+        zoom: var(--scoreboard-zoom, 1);
         display: inline-flex;
         justify-content: center;
         align-items: center;

--- a/src/graphics/live.html
+++ b/src/graphics/live.html
@@ -44,8 +44,8 @@
         --font-color: black;
         --font-score-size: 32px;
         --shield-size: 35px;
-        --shield-div-scale: 1.8;
-        --image-scale: 1;
+        --shield-div-scale: 1.6;
+        --image-scale: 1.05;
         --font-size-info: 12px;
         --font-size-time: 48px;
         --font-color-info: red;
@@ -75,7 +75,6 @@
 
 
         --font-size-card: calc(10px * var(--size-scale-factor, 1));
-
       }
 
       body {

--- a/src/graphics/live.html
+++ b/src/graphics/live.html
@@ -45,7 +45,7 @@
         --font-score-size: calc(32px * var(--size-scale-factor, 1));
         --shield-size: calc(35px * var(--size-scale-factor, 1));
         --shield-div-scale: calc(1.8 * var(--size-scale-factor, 1));
-        --image-scale: calc(1.2 * var(--size-scale-factor, 1));
+        --image-scale: calc(1 * var(--size-scale-factor, 1));
         --font-size-info: calc(12px * var(--size-scale-factor, 1));
         --font-size-time: calc(48px * var(--size-scale-factor, 1));
         --font-color-info: red;
@@ -179,6 +179,8 @@
       }
 
       .shield {
+        display: flex;
+        justify-content: center;
         border-radius: var(--shield-div-border-radius, calc(50px * var(--size-scale-factor, 1)) calc(25px * var(--size-scale-factor, 1)));
         overflow: hidden;
         rotate: -45deg;
@@ -229,10 +231,11 @@
       }
 
       .shield img {
-        display: flex;
-        width: var(--shield-size, 30px);
+        max-height: 100%;
+        max-width: 100%;
+        object-fit: cover;
         rotate: 45deg;
-        transform: scale(var(--image-scale, 1.2));
+        transform: scale(var(--image-scale, 1));
       }
 
       .local-team>.shield {

--- a/src/graphics/live.html
+++ b/src/graphics/live.html
@@ -34,27 +34,27 @@
 
         /* Not used yet */
 
-        --space-margin: calc(5px * var(--size-scale-factor, 1));
-        --scoreboard-space-margin: calc(10px * var(--size-scale-factor, 1));
-        --space-magin-score-left: calc(15px * var(--size-scale-factor, 1)) calc(5px* var(--size-scale-factor, 1)) calc(10px * var(--size-scale-factor, 1));
-        --space-margin-score-right: calc(5px * var(--size-scale-factor, 1)) calc(10px * var(--size-scale-factor, 1)) calc(5px * var(--size-scale-factor, 1)) calc(15px * var(--size-scale-factor, 1));
-        --score-border-radius-right: 0 calc(20px * var(--size-scale-factor, 1)) calc(20px * var(--size-scale-factor, 1)) 0;
-        --score-border-radius-left: calc(20px * var(--size-scale-factor, 1)) 0 0 calc(20px * var(--size-scale-factor, 1));
-        --font-size: calc(22px * var(--size-scale-factor, 1));
+        --space-margin: 5px;
+        --scoreboard-space-margin: 10px;
+        --space-magin-score-left: 15px 5px 10px;
+        --space-margin-score-right: 5px 10px 5px 15px;
+        --score-border-radius-right: 0 20px 20px 0;
+        --score-border-radius-left: 20px 0 0 20px;
+        --font-size: 22px;
         --font-color: black;
-        --font-score-size: calc(32px * var(--size-scale-factor, 1));
-        --shield-size: calc(35px * var(--size-scale-factor, 1));
-        --shield-div-scale: calc(1.8 * var(--size-scale-factor, 1));
-        --image-scale: calc(1 * var(--size-scale-factor, 1));
-        --font-size-info: calc(12px * var(--size-scale-factor, 1));
-        --font-size-time: calc(48px * var(--size-scale-factor, 1));
+        --font-score-size: 32px;
+        --shield-size: 35px;
+        --shield-div-scale: 1.8;
+        --image-scale: 1;
+        --font-size-info: 12px;
+        --font-size-time: 48px;
         --font-color-info: red;
-        --emty-goal-size: calc(16px * var(--size-scale-factor, 1));
+        --emty-goal-size: 16px;
 
         --scoreboard-font-color: black;
 
-        --stopwatch-padding: calc(5px * var(--size-scale-factor, 1)) calc(5px * var(--size-scale-factor, 1));
-        --stopwatch-border-radius: calc(10px * var(--size-scale-factor, 1));
+        --stopwatch-padding: 5px 5px;
+        --stopwatch-border-radius: 10px;
         --stopwatch-background-color: var(--vetusta-yellow-color, transparent);
         --stopwatch-background-time-color: black;
         --stopwatch-font-time-color: white;
@@ -65,8 +65,8 @@
         --result-background-color-visitor: var(--stopwatch-background-color);
         --result-font-color-visitor: var(--font-color);
 
-        --shield-div-border-radius: calc(50px * var(--size-scale-factor, 1)) calc(40px * var(--size-scale-factor, 1));
-        --shield-border-size: calc(5px * var(--size-scale-factor, 1));
+        --shield-div-border-radius: 50px 40px;
+        --shield-border-size: 5px;
         --shield-border-style: solid;
         --shield-border-color-local: var(--stopwatch-background-color);
         --shield-border-color-visitor: var(--stopwatch-background-color);

--- a/src/graphics/live.html
+++ b/src/graphics/live.html
@@ -235,11 +235,11 @@
         transform: scale(var(--image-scale, 1.2));
       }
 
-      .local-team>.shield>img {
+      .local-team>.shield {
         background-color: var(--local-shield-background-color, black);
       }
 
-      .visitor-team>.shield>img {
+      .visitor-team>.shield {
         background-color: var(--visitor-shield-background-color, yellow);
       }
 

--- a/src/graphics/live/scenes/in-match-scene.tsx
+++ b/src/graphics/live/scenes/in-match-scene.tsx
@@ -58,7 +58,7 @@ export default function InMatchScene(): ReactElement | null {
       ...prev,
       [BACKGROUND_COLOR_CSS_VAR]: BACKGROUND_COLOR,
       [BANNER_MAX_HEIGHT_CSS_VAR]: "130px",
-      [OFFSET_TOP_CSS_VAR]: "30px",
+      [OFFSET_TOP_CSS_VAR]: "20px",
       [OFFSET_BOTTOM_CSS_VAR]: "0",
       [OFFSET_LEFT_CSS_VAR]: "0",
       [OFFSET_RIGT_CSS_VAR]: "0",


### PR DESCRIPTION
- Fix shield background
- No calculated proportions, use zoom instead.
- Added `--scoreboard-zoom` css variable to control the size of the scoreboard.
- Scoreboard offset set to 20px instead of 30px.
- Adjusted the font size of the suspensions.