### PR TITLE
Fix: result before match start must not be shown

### DIFF
--- a/src/graphics/live/scenes/not-in-match.tsx
+++ b/src/graphics/live/scenes/not-in-match.tsx
@@ -11,11 +11,14 @@ import { Team } from "hooks/use-match-actions/types";
 import { useEffect } from "react";
 import { InfoNotInMatch } from "./not-in-match/info";
 import { TeamNotInMatch } from "./not-in-match/team";
+import { useStopwatchReplicantControl } from "hooks/use-stopwatch-replicant";
 
 export default function NotInMatch() {
   const { setCssVariables } = useCSSVariables();
+  const { stop } = useStopwatchReplicantControl();
 
   useEffect(() => {
+    stop();
     setCssVariables((prev) => ({
       ...prev,
       [BACKGROUND_COLOR_CSS_VAR]: "var(--vetusta-yellow, #fede58)",

--- a/src/graphics/live/scenes/not-in-match/team.tsx
+++ b/src/graphics/live/scenes/not-in-match/team.tsx
@@ -1,6 +1,7 @@
 import { useGraphicsReplicant } from "hooks/replicants/use-graphics-replicant";
 import { useMatchActions } from "hooks/use-match-actions";
 import { Team } from "hooks/use-match-actions/types";
+import { MaxTimeUnit, useStopwatchReplicantReader } from "hooks/use-stopwatch-replicant";
 import { TeamSideOptions, useTeamSide } from "hooks/use-team-side";
 import styled from "styled-components";
 
@@ -33,6 +34,14 @@ export function TeamNotInMatch({ team }: { team: Team }) {
   const { localTeamSide } = useTeamSide();
   const { localShield, visitorShield } = useGraphicsReplicant();
   const { goals } = useMatchActions();
+  const {
+    minutes = 0,
+    seconds = 0,
+    // milliseconds = 0,
+    // periodTime = 0,
+  } = useStopwatchReplicantReader({
+    maxTimeUnit: MaxTimeUnit.MINUTES,
+  });
 
   const isLeftSide =
     (team === Team.LOCAL && localTeamSide === TeamSideOptions.LEFT) ||
@@ -46,7 +55,7 @@ export function TeamNotInMatch({ team }: { team: Team }) {
     <>
       <SideShield data-position={dataPosition}>
         <img src={src} alt="Shield" />
-        <div className="score">{scoreString}</div>
+        {minutes > 0 || seconds > 0 ? <div className="score">{scoreString}</div> : null}
       </SideShield>
     </>
   );


### PR DESCRIPTION
- Fix when `not-in-match` and match did not start, do not show a result.
- Fix when change to `not-in-match` stop the stopwatch (only works if the scene is opened).